### PR TITLE
Improve Chat Security

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -183,7 +183,7 @@ body[user-role="operative"] {
 				margin: 0px 2px 2px 0px;
 			}
 		}
-		&.selectable { 
+		&.selectable {
 			cursor: pointer;
 
 			&:hover {
@@ -251,6 +251,7 @@ body[user-role="operative"] {
 		background-color: white;
 		border-radius: 10px;
 		margin-bottom: 10px;
+		word-wrap: break-word;
 
 		.body { padding: 10px; }
 		.author {
@@ -265,8 +266,8 @@ body[user-role="operative"] {
 		}
 		&[data-team="blue"] .author { background-color: $blue; }
 		&[data-team="red"] .author { background-color: $red; }
-		
-		/* if the current user sent the message, hide author and 
+
+		/* if the current user sent the message, hide author and
 		make the whole thing the color of their team */
 		&[data-self="true"] {
 			color: white;
@@ -276,7 +277,7 @@ body[user-role="operative"] {
 			&[data-team="red"] { background-color: $red; }
 		}
 	}
-	.msg-cont { 
+	.msg-cont {
 		background-color: lightgrey;
 		padding: 10px 40px;
 		overflow-y: scroll;
@@ -432,7 +433,7 @@ body[user-role="operative"] {
 		}
 		&.red {
 			background-color: $red;
-			
+
 			.player.self { color: $red; }
 		}
 		.title {

--- a/js/pages/game.js
+++ b/js/pages/game.js
@@ -77,6 +77,7 @@ function changeTurn(team) {
 
 function sendMessage() {
 	var message = $('.send-msg input[type="text"]').val();
+	message = escapeHtml(message); // escape message for safety
 	sendSocket({ action: 'sendMessage', text: message });
 	$('.send-msg input[type="text"]').val('');
 }
@@ -86,14 +87,10 @@ function addMessage(message, name, team) {
 	let maybeSelf = name === me.name ? ' data-self="true"' : "";
 	$('.chat .msg-cont').append(
 		`<div class="msg" data-team="${teamString}"${maybeSelf}>
-			<div class="body"></div>
-			<div class="author"></div>
+			<div class="body">${message}</div>
+			<div class="author">${name}</div>
 		</div>`
 	);
-
-	// Apply message and name using text() to prevent <script> injection
-	$('.chat .msg:last-of-type .body').text(message);
-	$('.chat .msg:last-of-type .author').text(name)
 
 	// Scroll to bottom
 	$(".msg-cont").scrollTop($(".msg-cont")[0].scrollHeight);

--- a/js/pages/game.js
+++ b/js/pages/game.js
@@ -86,10 +86,14 @@ function addMessage(message, name, team) {
 	let maybeSelf = name === me.name ? ' data-self="true"' : "";
 	$('.chat .msg-cont').append(
 		`<div class="msg" data-team="${teamString}"${maybeSelf}>
-			<div class="body">${message}</div>
-			<div class="author">${name}</div>
+			<div class="body"></div>
+			<div class="author"></div>
 		</div>`
 	);
+
+	// Apply message and name using text() to prevent <script> injection
+	$('.chat .msg:last-of-type .body').text(message);
+	$('.chat .msg:last-of-type .author').text(name)
 
 	// Scroll to bottom
 	$(".msg-cont").scrollTop($(".msg-cont")[0].scrollHeight);

--- a/js/pages/registration.js
+++ b/js/pages/registration.js
@@ -12,6 +12,7 @@ function goToRoster() {
 function registerName() {
 	if(!$('#register').hasClass('disabled')) { // only continue if button is enabled
 		var name = $('.registration-page-cont input').val();
+		name = escapeHtml(name); // escape name for safety
 
 		try {
 			sendSocket({ action: "setName", name: name });
@@ -20,12 +21,12 @@ function registerName() {
 			console.error(error);
 			showOverlay('websocket-error');
 		}
-	}	
+	}
 }
 
 function checkEnteredName() {
 	var name = $('.registration-page-cont input').val();
-	
+
 	if(name.length > 0)
 		$('#register').removeClass('disabled');
 	else

--- a/js/utils.js
+++ b/js/utils.js
@@ -57,3 +57,21 @@ function sendSocket(data) {
 
 	socket.send(JSON.stringify(data));
 }
+
+// Escapes an unsafe string so it can be put into HTML
+var entityMap = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#39;',
+	'/': '&#x2F;',
+	'`': '&#x60;',
+	'=': '&#x3D;'
+};
+
+function escapeHtml (string) {
+	return String(string).replace(/[&<>"'`=\/]/g, function (s) {
+		return entityMap[s];
+	});
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -17,7 +17,7 @@ function setMe(newMe) {
 		$('body').attr('user-team', 'red');
 
 	// Update name in header
-	$('header .name').text(me.name);
+	$('header .name').html(me.name);
 
 	// Update role in header
 	if(me.role == SPY) {


### PR DESCRIPTION
This pull requests adds an `escapeHtml` function from [a StackOverflow answer](https://stackoverflow.com/a/12034334) on the subject, and implements it when taking the name input and chat input and sending it to the server. However, this could still be exploited if someone writes their own javascript in the terminal to send a message to the server that has not been sanitized, so server based sanitization might also be useful.

Screenshot of roster showing attempted script injection:
![screenshot from 2017-11-09 19-34-48](https://user-images.githubusercontent.com/3187531/32638646-e4ddffea-c585-11e7-97b0-521cfe9033b1.png)

Screenshot of chat showing the same:
![screenshot from 2017-11-09 19-35-07](https://user-images.githubusercontent.com/3187531/32638645-e4d3f522-c585-11e7-9319-d29037cfb6f4.png)

This pull request should fix #4.