### PR TITLE
Moved Heroku Websocket Reference to Use WSS

### DIFF
--- a/js/socket.js
+++ b/js/socket.js
@@ -1,8 +1,7 @@
 function setupSocket() {
 	// Create WebSocket connection - TODO: unhard code this
-	// socket = new WebSocket('wss://localhost:3000');
 	if(window.location.host.indexOf('localhost') > -1) //if on localhost
-		socket = new WebSocket('wss://localhost:8000');
+		socket = new WebSocket('ws://localhost:8000');
 	else
 		socket = new WebSocket('wss://codenames-backend.herokuapp.com/');
 

--- a/js/socket.js
+++ b/js/socket.js
@@ -1,10 +1,10 @@
 function setupSocket() {
 	// Create WebSocket connection - TODO: unhard code this
-	// socket = new WebSocket('ws://localhost:3000');
+	// socket = new WebSocket('wss://localhost:3000');
 	if(window.location.host.indexOf('localhost') > -1) //if on localhost
-		socket = new WebSocket('ws://localhost:8000');
+		socket = new WebSocket('wss://localhost:8000');
 	else
-		socket = new WebSocket('ws://codenames-backend.herokuapp.com/');
+		socket = new WebSocket('wss://codenames-backend.herokuapp.com/');
 
 	// Connection opened
 	socket.addEventListener('open', function (event) {});


### PR DESCRIPTION
This secure websocket should work with HTTPS, fixing the current bug preventing the websocket from loading over HTTPS. This should still work over HTTP however, and should protect all user data. I've verified locally that the production websocket works properly, and reviewers can do this by simply commenting out the conditional logic for local so that the prod websocket is always used.